### PR TITLE
[168] Add in-memory Service Bus messaging provider for testing

### DIFF
--- a/Memoria.sln
+++ b/Memoria.sln
@@ -96,6 +96,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.EventSourcing.Store
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.EventSourcing.Store.Cosmos.InMemory.Tests", "tests\Memoria.EventSourcing.Store.Cosmos.InMemory.Tests\Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.csproj", "{4E0425ED-5C1B-4B4C-8AFE-55ECE72F50A4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Messaging.ServiceBus.InMemory", "src\Memoria.Messaging.ServiceBus.InMemory\Memoria.Messaging.ServiceBus.InMemory.csproj", "{D870C994-9CB8-4301-8AFF-3AE36151F9F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Messaging.ServiceBus.InMemory.Tests", "tests\Memoria.Messaging.ServiceBus.InMemory.Tests\Memoria.Messaging.ServiceBus.InMemory.Tests.csproj", "{211CF97E-6383-4411-8AAE-6C366BC0AB8D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -210,6 +214,14 @@ Global
 		{4E0425ED-5C1B-4B4C-8AFE-55ECE72F50A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E0425ED-5C1B-4B4C-8AFE-55ECE72F50A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E0425ED-5C1B-4B4C-8AFE-55ECE72F50A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D870C994-9CB8-4301-8AFF-3AE36151F9F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D870C994-9CB8-4301-8AFF-3AE36151F9F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D870C994-9CB8-4301-8AFF-3AE36151F9F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D870C994-9CB8-4301-8AFF-3AE36151F9F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{211CF97E-6383-4411-8AAE-6C366BC0AB8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{211CF97E-6383-4411-8AAE-6C366BC0AB8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{211CF97E-6383-4411-8AAE-6C366BC0AB8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{211CF97E-6383-4411-8AAE-6C366BC0AB8D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -242,6 +254,8 @@ Global
 		{CC231C0F-83E5-4481-BAAE-35407A415995} = {90721148-631D-47AB-845C-8472AE48BC89}
 		{59236643-1C12-415A-8FB8-193A480DEA0D} = {8E88F39E-B2DF-4122-821F-0EECC7343773}
 		{4E0425ED-5C1B-4B4C-8AFE-55ECE72F50A4} = {8E88F39E-B2DF-4122-821F-0EECC7343773}
+		{D870C994-9CB8-4301-8AFF-3AE36151F9F1} = {90721148-631D-47AB-845C-8472AE48BC89}
+		{211CF97E-6383-4411-8AAE-6C366BC0AB8D} = {8E88F39E-B2DF-4122-821F-0EECC7343773}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {154500C3-9A83-4F15-9D78-E1C285AD80AE}

--- a/src/Memoria.Messaging.ServiceBus.InMemory/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Memoria.Messaging.ServiceBus.InMemory/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Memoria.Messaging.ServiceBus.InMemory.Extensions;
+
+/// <summary>
+/// Provides extension methods for configuring Memoria with the in-memory Service Bus messaging provider.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the in-memory Service Bus messaging provider to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection to add the provider to.</param>
+    public static void AddMemoriaInMemoryServiceBus(this IServiceCollection services)
+    {
+        var storage = new InMemoryServiceBusStorage();
+        services.AddSingleton(storage);
+        services.Replace(ServiceDescriptor.Singleton<IMessagingProvider>(_ => new InMemoryServiceBusMessagingProvider(storage)));
+    }
+
+    /// <summary>
+    /// Adds the in-memory Service Bus messaging provider to the service collection with a shared storage instance.
+    /// </summary>
+    /// <param name="services">The service collection to add the provider to.</param>
+    /// <param name="storage">The shared storage instance for test verification.</param>
+    public static void AddMemoriaInMemoryServiceBus(this IServiceCollection services, InMemoryServiceBusStorage storage)
+    {
+        services.AddSingleton(storage);
+        services.Replace(ServiceDescriptor.Singleton<IMessagingProvider>(_ => new InMemoryServiceBusMessagingProvider(storage)));
+    }
+}

--- a/src/Memoria.Messaging.ServiceBus.InMemory/InMemoryServiceBusMessagingProvider.cs
+++ b/src/Memoria.Messaging.ServiceBus.InMemory/InMemoryServiceBusMessagingProvider.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using Memoria.Results;
+using Newtonsoft.Json;
+
+namespace Memoria.Messaging.ServiceBus.InMemory;
+
+/// <summary>
+/// Provides in-memory messaging functionality for testing and local development
+/// without requiring an Azure Service Bus connection.
+/// </summary>
+public class InMemoryServiceBusMessagingProvider(InMemoryServiceBusStorage storage) : IMessagingProvider
+{
+    /// <summary>
+    /// Sends a message to the specified queue (stored in-memory).
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message, which must implement IQueueMessage.</typeparam>
+    /// <param name="message">The message to send.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating success or failure.</returns>
+    public Task<Result> SendQueueMessage<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : IQueueMessage
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(message.QueueName))
+            {
+                return Task.FromResult<Result>(new Failure(Title: "Queue name", Description: "Queue name cannot be null or empty"));
+            }
+
+            var inMemoryMessage = CreateInMemoryMessage(message, message.QueueName);
+            storage.AddMessage(inMemoryMessage);
+
+            return Task.FromResult(Result.Ok());
+        }
+        catch (Exception ex)
+        {
+            var tagList = new TagList { { "Operation description", "Sending queue message" } };
+            Activity.Current?.AddException(ex, tagList, DateTimeOffset.UtcNow);
+            return Task.FromResult<Result>(new Failure
+            (
+                Title: "Error",
+                Description: "There was an error when processing the request"
+            ));
+        }
+    }
+
+    /// <summary>
+    /// Sends a message to the specified topic (stored in-memory).
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message, which must implement ITopicMessage.</typeparam>
+    /// <param name="message">The message to send.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating success or failure.</returns>
+    public Task<Result> SendTopicMessage<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : ITopicMessage
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(message.TopicName))
+            {
+                return Task.FromResult<Result>(new Failure(Title: "Topic name", Description: "Topic name cannot be null or empty"));
+            }
+
+            var inMemoryMessage = CreateInMemoryMessage(message, message.TopicName);
+            storage.AddMessage(inMemoryMessage);
+
+            return Task.FromResult(Result.Ok());
+        }
+        catch (Exception ex)
+        {
+            var tagList = new TagList { { "Operation description", "Sending topic message" } };
+            Activity.Current?.AddException(ex, tagList, DateTimeOffset.UtcNow);
+            return Task.FromResult<Result>(new Failure
+            (
+                Title: "Error",
+                Description: "There was an error when processing the request"
+            ));
+        }
+    }
+
+    private static InMemoryMessage CreateInMemoryMessage<TMessage>(TMessage message, string entityName) where TMessage : IMessage
+    {
+        var json = JsonConvert.SerializeObject(message);
+
+        var inMemoryMessage = new InMemoryMessage
+        {
+            EntityName = entityName,
+            MessageBody = json,
+            ContentType = "application/json",
+            MessageId = Guid.NewGuid().ToString(),
+            OriginalMessageType = message.GetType().FullName,
+            SentAt = DateTimeOffset.UtcNow
+        };
+
+        if (message.ScheduledEnqueueTimeUtc.HasValue)
+        {
+            inMemoryMessage.ScheduledEnqueueTime = message.ScheduledEnqueueTimeUtc.Value;
+        }
+
+        foreach (var property in message.Properties)
+        {
+            inMemoryMessage.ApplicationProperties[property.Key] = property.Value;
+        }
+
+        return inMemoryMessage;
+    }
+}

--- a/src/Memoria.Messaging.ServiceBus.InMemory/InMemoryServiceBusStorage.cs
+++ b/src/Memoria.Messaging.ServiceBus.InMemory/InMemoryServiceBusStorage.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using Newtonsoft.Json;
+
+namespace Memoria.Messaging.ServiceBus.InMemory;
+
+/// <summary>
+/// Shared in-memory storage for Service Bus messaging implementation.
+/// This class provides thread-safe storage for sent messages, allowing test verification.
+/// </summary>
+public class InMemoryServiceBusStorage
+{
+    private readonly ConcurrentBag<InMemoryMessage> _messages = [];
+
+    /// <summary>
+    /// Gets all stored messages.
+    /// </summary>
+    public IReadOnlyList<InMemoryMessage> GetMessages()
+    {
+        return _messages.ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Gets all stored messages for a specific entity (queue or topic name).
+    /// </summary>
+    public IEnumerable<InMemoryMessage> GetMessagesForEntity(string entityName)
+    {
+        return _messages.Where(m => string.Equals(m.EntityName, entityName, StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    /// <summary>
+    /// Gets all stored messages that can be deserialized to the specified type.
+    /// </summary>
+    public IEnumerable<T> GetMessages<T>() where T : class
+    {
+        var targetTypeName = typeof(T).FullName;
+
+        return _messages
+            .Where(m => m.ContentType == "application/json")
+            .Where(m => m.OriginalMessageType == targetTypeName)
+            .Select(m =>
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<T>(m.MessageBody);
+                }
+                catch
+                {
+                    return null;
+                }
+            })
+            .Where(m => m != null)
+            .Cast<T>()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Gets all stored messages for a specific entity that can be deserialized to the specified type.
+    /// </summary>
+    public IEnumerable<T> GetMessagesForEntity<T>(string entityName) where T : class
+    {
+        var targetTypeName = typeof(T).FullName;
+
+        return _messages
+            .Where(m => string.Equals(m.EntityName, entityName, StringComparison.OrdinalIgnoreCase))
+            .Where(m => m.ContentType == "application/json")
+            .Where(m => m.OriginalMessageType == targetTypeName)
+            .Select(m =>
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<T>(m.MessageBody);
+                }
+                catch
+                {
+                    return null;
+                }
+            })
+            .Where(m => m != null)
+            .Cast<T>()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Gets the number of messages sent to a specific entity.
+    /// </summary>
+    public int GetMessageCountForEntity(string entityName)
+    {
+        return _messages.Count(m => string.Equals(m.EntityName, entityName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets the total number of stored messages.
+    /// </summary>
+    public int TotalMessageCount => _messages.Count;
+
+    /// <summary>
+    /// Adds a message to the storage.
+    /// </summary>
+    internal void AddMessage(InMemoryMessage message)
+    {
+        _messages.Add(message);
+    }
+
+    /// <summary>
+    /// Clears all stored data. Useful for test cleanup.
+    /// </summary>
+    public void Clear()
+    {
+        while (!_messages.IsEmpty)
+        {
+            _messages.TryTake(out _);
+        }
+    }
+}
+
+/// <summary>
+/// Represents a message captured by the in-memory Service Bus provider.
+/// </summary>
+public class InMemoryMessage
+{
+    public string EntityName { get; set; } = string.Empty;
+    public string MessageBody { get; set; } = string.Empty;
+    public string? ContentType { get; set; }
+    public string? MessageId { get; set; }
+    public DateTime? ScheduledEnqueueTime { get; set; }
+    public Dictionary<string, object> ApplicationProperties { get; set; } = new();
+    public string? OriginalMessageType { get; set; }
+    public DateTimeOffset SentAt { get; set; }
+}

--- a/src/Memoria.Messaging.ServiceBus.InMemory/Memoria.Messaging.ServiceBus.InMemory.csproj
+++ b/src/Memoria.Messaging.ServiceBus.InMemory/Memoria.Messaging.ServiceBus.InMemory.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Memoria\Memoria.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Features/CommandSenderWithPublishingTests.cs
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Features/CommandSenderWithPublishingTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Commands;
+using Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Messages;
+using Xunit;
+
+namespace Memoria.Messaging.ServiceBus.InMemory.Tests.Features;
+
+public class CommandSenderWithPublishingTests : TestBase
+{
+    [Fact]
+    public async Task SendAndPublish_ShouldPublishServiceBusMessages()
+    {
+        var result = await Dispatcher.SendAndPublish(new DoSomething(Id: Guid.NewGuid(), Name: "Test message data"));
+
+        result.Should().NotBeNull();
+        result.CommandResult.IsSuccess.Should().BeTrue();
+
+        var sentMessages = Storage.GetMessages();
+        sentMessages.Should().HaveCount(1);
+
+        var sentMessage = sentMessages[0];
+        sentMessage.EntityName.Should().Be("test-queue");
+        sentMessage.ContentType.Should().Be("application/json");
+        sentMessage.MessageId.Should().NotBeNullOrEmpty();
+
+        var deserializedMessages = Storage.GetMessages<TestQueueMessage>().ToArray();
+        deserializedMessages.Should().HaveCount(1);
+
+        var deserializedMessage = deserializedMessages.First();
+        deserializedMessage.QueueName.Should().Be("test-queue");
+        deserializedMessage.TestData.Should().Be("Test message data");
+    }
+}

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Features/InMemoryServiceBusMessagingProviderTests.cs
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Features/InMemoryServiceBusMessagingProviderTests.cs
@@ -1,0 +1,246 @@
+using FluentAssertions;
+using Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Messages;
+using Xunit;
+
+namespace Memoria.Messaging.ServiceBus.InMemory.Tests.Features;
+
+public class InMemoryServiceBusMessagingProviderTests
+{
+    private readonly InMemoryServiceBusStorage _storage = new();
+
+    [Fact]
+    public async Task SendQueueMessage_WithValidMessage_ShouldSucceed()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage
+        {
+            QueueName = "test-queue",
+            TestData = "Test message data",
+            Properties = new Dictionary<string, object> { { "key1", "value1" } }
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        var sentMessages = _storage.GetMessages();
+        sentMessages.Should().HaveCount(1);
+
+        var sentMessage = sentMessages[0];
+        sentMessage.EntityName.Should().Be("test-queue");
+        sentMessage.ContentType.Should().Be("application/json");
+        sentMessage.MessageId.Should().NotBeNullOrEmpty();
+
+        var deserializedMessages = _storage.GetMessages<TestQueueMessage>().ToArray();
+        deserializedMessages.Should().HaveCount(1);
+
+        var deserializedMessage = deserializedMessages.First();
+        deserializedMessage.QueueName.Should().Be("test-queue");
+        deserializedMessage.TestData.Should().Be("Test message data");
+    }
+
+    [Fact]
+    public async Task SendTopicMessage_WithValidMessage_ShouldSucceed()
+    {
+        var provider = CreateProvider();
+        var message = new TestTopicMessage
+        {
+            TopicName = "test-topic",
+            TestData = "Test topic message",
+            Properties = new Dictionary<string, object>
+            {
+                { "MessageType", "TestEvent" },
+                { "Version", 1 }
+            }
+        };
+
+        var result = await provider.SendTopicMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        var topicMessages = _storage.GetMessagesForEntity("test-topic");
+        topicMessages.Should().HaveCount(1);
+
+        _storage.GetMessageCountForEntity("test-topic").Should().Be(1);
+        _storage.TotalMessageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendQueueMessage_WithEmptyQueueName_ShouldReturnFailure()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage
+        {
+            QueueName = string.Empty,
+            TestData = "Test data"
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().NotBeNull();
+        result.Failure!.Title.Should().Be("Queue name");
+        result.Failure.Description.Should().Be("Queue name cannot be null or empty");
+
+        _storage.TotalMessageCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SendTopicMessage_WithEmptyTopicName_ShouldReturnFailure()
+    {
+        var provider = CreateProvider();
+        var message = new TestTopicMessage
+        {
+            TopicName = string.Empty,
+            TestData = "Test data"
+        };
+
+        var result = await provider.SendTopicMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().NotBeNull();
+        result.Failure!.Title.Should().Be("Topic name");
+        result.Failure.Description.Should().Be("Topic name cannot be null or empty");
+    }
+
+    [Fact]
+    public async Task SendQueueMessage_WithScheduledEnqueueTime_ShouldPreserveScheduledTime()
+    {
+        var provider = CreateProvider();
+        var scheduledTime = DateTime.UtcNow.AddHours(1);
+        var message = new TestQueueMessage
+        {
+            QueueName = "scheduled-queue",
+            TestData = "Scheduled message",
+            ScheduledEnqueueTimeUtc = scheduledTime
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var sentMessages = _storage.GetMessages();
+        sentMessages.Should().HaveCount(1);
+
+        var sentMessage = sentMessages.First();
+        sentMessage.ScheduledEnqueueTime.Should().NotBeNull();
+        sentMessage.ScheduledEnqueueTime!.Value.Should().BeCloseTo(scheduledTime, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task SendQueueMessage_WithApplicationProperties_ShouldPreserveProperties()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage
+        {
+            QueueName = "properties-queue",
+            TestData = "Message with properties",
+            Properties = new Dictionary<string, object>
+            {
+                { "CustomProperty1", "Value1" },
+                { "CustomProperty2", 42 },
+                { "CustomProperty3", true }
+            }
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var sentMessages = _storage.GetMessages();
+        var sentMessage = sentMessages.First();
+
+        sentMessage.ApplicationProperties.Should().HaveCount(3);
+        sentMessage.ApplicationProperties["CustomProperty1"].Should().Be("Value1");
+        sentMessage.ApplicationProperties["CustomProperty2"].Should().Be(42);
+        sentMessage.ApplicationProperties["CustomProperty3"].Should().Be(true);
+    }
+
+    [Fact]
+    public async Task SendMultipleMessages_ShouldCaptureAllMessages()
+    {
+        var provider = CreateProvider();
+        var queueMessage1 = new TestQueueMessage { QueueName = "queue1", TestData = "Queue message 1" };
+        var queueMessage2 = new TestQueueMessage { QueueName = "queue2", TestData = "Queue message 2" };
+        var topicMessage = new TestTopicMessage { TopicName = "topic1", TestData = "Topic message 1" };
+
+        await provider.SendQueueMessage(queueMessage1);
+        await provider.SendQueueMessage(queueMessage2);
+        await provider.SendTopicMessage(topicMessage);
+
+        _storage.TotalMessageCount.Should().Be(3);
+        _storage.GetMessageCountForEntity("queue1").Should().Be(1);
+        _storage.GetMessageCountForEntity("queue2").Should().Be(1);
+        _storage.GetMessageCountForEntity("topic1").Should().Be(1);
+
+        var allQueueMessages = _storage.GetMessages<TestQueueMessage>();
+        allQueueMessages.Should().HaveCount(2);
+
+        var allTopicMessages = _storage.GetMessages<TestTopicMessage>();
+        allTopicMessages.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Clear_ShouldRemoveAllStoredMessages()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage { QueueName = "test-queue", TestData = "Test" };
+
+        await provider.SendQueueMessage(message);
+        _storage.TotalMessageCount.Should().Be(1);
+
+        _storage.Clear();
+
+        _storage.TotalMessageCount.Should().Be(0);
+        _storage.GetMessages().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMessagesByType_ShouldReturnOnlyMatchingType()
+    {
+        var provider = CreateProvider();
+        var queueMessage = new TestQueueMessage { QueueName = "queue1", TestData = "Queue data" };
+        var topicMessage = new TestTopicMessage { TopicName = "topic1", TestData = "Topic data" };
+
+        await provider.SendQueueMessage(queueMessage);
+        await provider.SendTopicMessage(topicMessage);
+
+        _storage.TotalMessageCount.Should().Be(2);
+
+        var queueMessages = _storage.GetMessages<TestQueueMessage>().ToArray();
+        queueMessages.Should().HaveCount(1);
+        queueMessages.First().TestData.Should().Be("Queue data");
+
+        var topicMessages = _storage.GetMessages<TestTopicMessage>().ToArray();
+        topicMessages.Should().HaveCount(1);
+        topicMessages.First().TestData.Should().Be("Topic data");
+    }
+
+    [Fact]
+    public async Task GetMessagesForEntity_ByType_ShouldReturnOnlyMatchingEntityAndType()
+    {
+        var provider = CreateProvider();
+        var message1 = new TestQueueMessage { QueueName = "queue1", TestData = "Message 1" };
+        var message2 = new TestQueueMessage { QueueName = "queue2", TestData = "Message 2" };
+
+        await provider.SendQueueMessage(message1);
+        await provider.SendQueueMessage(message2);
+
+        var queue1Messages = _storage.GetMessagesForEntity<TestQueueMessage>("queue1").ToArray();
+        queue1Messages.Should().HaveCount(1);
+        queue1Messages.First().TestData.Should().Be("Message 1");
+
+        var queue2Messages = _storage.GetMessagesForEntity<TestQueueMessage>("queue2").ToArray();
+        queue2Messages.Should().HaveCount(1);
+        queue2Messages.First().TestData.Should().Be("Message 2");
+    }
+
+    private InMemoryServiceBusMessagingProvider CreateProvider()
+    {
+        return new InMemoryServiceBusMessagingProvider(_storage);
+    }
+}

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Memoria.Messaging.ServiceBus.InMemory.Tests.csproj
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Memoria.Messaging.ServiceBus.InMemory.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="7.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Memoria.Messaging.ServiceBus.InMemory\Memoria.Messaging.ServiceBus.InMemory.csproj" />
+      <ProjectReference Include="..\..\src\Memoria\Memoria.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Commands/DoSomething.cs
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Commands/DoSomething.cs
@@ -1,0 +1,5 @@
+using Memoria.Commands;
+
+namespace Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Commands;
+
+public record DoSomething(Guid Id, string Name) : ICommand<CommandResponse>;

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Commands/Handlers/DoSomethingHandler.cs
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Commands/Handlers/DoSomethingHandler.cs
@@ -1,0 +1,27 @@
+using Memoria.Commands;
+using Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Messages;
+using Memoria.Results;
+
+namespace Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Commands.Handlers;
+
+public class DoSomethingHandler : ICommandHandler<DoSomething, CommandResponse>
+{
+    public async Task<Result<CommandResponse>> Handle(DoSomething command, CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+
+        var queueMessage = new TestQueueMessage
+        {
+            TestData = command.Name,
+            QueueName = "test-queue",
+            Properties = new Dictionary<string, object> { { "CommandId", command.Id } }
+        };
+
+        var response = new CommandResponse(
+            queueMessage,
+            new { Message = $"Successfully processed command for: {command.Name}" }
+        );
+
+        return response;
+    }
+}

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Messages/TestQueueMessage.cs
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Messages/TestQueueMessage.cs
@@ -1,0 +1,9 @@
+namespace Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Messages;
+
+public class TestQueueMessage : IQueueMessage
+{
+    public string QueueName { get; set; } = string.Empty;
+    public DateTime? ScheduledEnqueueTimeUtc { get; set; }
+    public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+    public string TestData { get; set; } = string.Empty;
+}

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Messages/TestTopicMessage.cs
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/Models/Messages/TestTopicMessage.cs
@@ -1,0 +1,9 @@
+namespace Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Messages;
+
+public class TestTopicMessage : ITopicMessage
+{
+    public string TopicName { get; set; } = string.Empty;
+    public DateTime? ScheduledEnqueueTimeUtc { get; set; }
+    public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+    public string TestData { get; set; } = string.Empty;
+}

--- a/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/TestBase.cs
+++ b/tests/Memoria.Messaging.ServiceBus.InMemory.Tests/TestBase.cs
@@ -1,0 +1,31 @@
+using Memoria.Commands;
+using Memoria.Messaging.ServiceBus.InMemory;
+using Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Commands;
+using Memoria.Messaging.ServiceBus.InMemory.Tests.Models.Commands.Handlers;
+using Memoria.Notifications;
+using Memoria.Queries;
+using Memoria.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Memoria.Messaging.ServiceBus.InMemory.Tests;
+
+public abstract class TestBase
+{
+    protected readonly InMemoryServiceBusStorage Storage;
+    protected readonly IDispatcher Dispatcher;
+
+    protected TestBase()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<DoSomething, CommandResponse>, DoSomethingHandler>()
+            .BuildServiceProvider();
+
+        Storage = new InMemoryServiceBusStorage();
+        var messagingProvider = new InMemoryServiceBusMessagingProvider(Storage);
+        var messagePublisher = new MessagePublisher(messagingProvider);
+        var commandSender = new CommandSender(serviceProvider, Substitute.For<IValidationService>(), Substitute.For<INotificationPublisher>(), messagePublisher);
+
+        Dispatcher = new Dispatcher(commandSender, Substitute.For<IQueryProcessor>(), Substitute.For<INotificationPublisher>());
+    }
+}


### PR DESCRIPTION
Introduce Memoria.Messaging.ServiceBus.InMemory, an in-memory implementation of IMessagingProvider that enables testing and local development without an Azure Service Bus connection. Follows the same pattern as the existing Cosmos InMemory provider.