### PR TITLE
Add in-memory RabbitMQ messaging provider for testing

### DIFF
--- a/Memoria.sln
+++ b/Memoria.sln
@@ -100,6 +100,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Messaging.ServiceBu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Messaging.ServiceBus.InMemory.Tests", "tests\Memoria.Messaging.ServiceBus.InMemory.Tests\Memoria.Messaging.ServiceBus.InMemory.Tests.csproj", "{211CF97E-6383-4411-8AAE-6C366BC0AB8D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Messaging.RabbitMq.InMemory", "src\Memoria.Messaging.RabbitMq.InMemory\Memoria.Messaging.RabbitMq.InMemory.csproj", "{11DF57D6-5642-4E03-9CBC-2892A20A3B06}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memoria.Messaging.RabbitMq.InMemory.Tests", "tests\Memoria.Messaging.RabbitMq.InMemory.Tests\Memoria.Messaging.RabbitMq.InMemory.Tests.csproj", "{3B39C197-29E7-4FBB-99AD-B1A5509E6D63}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -222,6 +226,14 @@ Global
 		{211CF97E-6383-4411-8AAE-6C366BC0AB8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{211CF97E-6383-4411-8AAE-6C366BC0AB8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{211CF97E-6383-4411-8AAE-6C366BC0AB8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11DF57D6-5642-4E03-9CBC-2892A20A3B06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11DF57D6-5642-4E03-9CBC-2892A20A3B06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11DF57D6-5642-4E03-9CBC-2892A20A3B06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11DF57D6-5642-4E03-9CBC-2892A20A3B06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B39C197-29E7-4FBB-99AD-B1A5509E6D63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B39C197-29E7-4FBB-99AD-B1A5509E6D63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B39C197-29E7-4FBB-99AD-B1A5509E6D63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B39C197-29E7-4FBB-99AD-B1A5509E6D63}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -256,6 +268,8 @@ Global
 		{4E0425ED-5C1B-4B4C-8AFE-55ECE72F50A4} = {8E88F39E-B2DF-4122-821F-0EECC7343773}
 		{D870C994-9CB8-4301-8AFF-3AE36151F9F1} = {90721148-631D-47AB-845C-8472AE48BC89}
 		{211CF97E-6383-4411-8AAE-6C366BC0AB8D} = {8E88F39E-B2DF-4122-821F-0EECC7343773}
+		{11DF57D6-5642-4E03-9CBC-2892A20A3B06} = {90721148-631D-47AB-845C-8472AE48BC89}
+		{3B39C197-29E7-4FBB-99AD-B1A5509E6D63} = {8E88F39E-B2DF-4122-821F-0EECC7343773}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {154500C3-9A83-4F15-9D78-E1C285AD80AE}

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ If you're using this repository for your learning, samples, workshop, or your pr
 
 ## 🗺️ Roadmap
 
-### ⏳ In Progress
-- New package for in-memory RabbitMQ for easier testing in projects using Memoria
-
 ### ✅ Recently Completed
 - New package for in-memory Service Bus for easier testing in projects using Memoria
+- New package for in-memory RabbitMQ for easier testing in projects using Memoria
 
 ### ⏭️ Next
 - Create an ecommerce demo application to showcase Memoria features
@@ -67,6 +65,7 @@ If you're using this repository for your learning, samples, workshop, or your pr
 | [Memoria.EventSourcing.Store.EntityFrameworkCore](https://www.nuget.org/packages/Memoria.EventSourcing.Store.EntityFrameworkCore)                   | [![Nuget Package](https://img.shields.io/badge/nuget-1.0.0-blue.svg)](https://www.nuget.org/packages/Memoria.EventSourcing.Store.EntityFrameworkCore)          |
 | [Memoria.EventSourcing.Store.EntityFrameworkCore.Identity](https://www.nuget.org/packages/Memoria.EventSourcing.Store.EntityFrameworkCore.Identity) | [![Nuget Package](https://img.shields.io/badge/nuget-1.0.0-blue.svg)](https://www.nuget.org/packages/Memoria.EventSourcing.Store.EntityFrameworkCore.Identity) |
 | [Memoria.Messaging.RabbitMq](https://www.nuget.org/packages/Memoria.Messaging.RabbitMq)                                                             | [![Nuget Package](https://img.shields.io/badge/nuget-1.0.0-blue.svg)](https://www.nuget.org/packages/Memoria.Messaging.RabbitMq)                               |
+| [Memoria.Messaging.RabbitMq.InMemory](https://www.nuget.org/packages/Memoria.Messaging.RabbitMq.InMemory)                                           | [![Nuget Package](https://img.shields.io/badge/nuget-1.0.0-blue.svg)](https://www.nuget.org/packages/Memoria.Messaging.RabbitMq.InMemory)                      |
 | [Memoria.Messaging.ServiceBus](https://www.nuget.org/packages/Memoria.Messaging.ServiceBus)                                                         | [![Nuget Package](https://img.shields.io/badge/nuget-1.0.0-blue.svg)](https://www.nuget.org/packages/Memoria.Messaging.ServiceBus)                             |
 | [Memoria.Messaging.ServiceBus.InMemory](https://www.nuget.org/packages/Memoria.Messaging.ServiceBus.InMemory)                                       | [![Nuget Package](https://img.shields.io/badge/nuget-1.0.0-blue.svg)](https://www.nuget.org/packages/Memoria.Messaging.ServiceBus.InMemory)                    |
 | [Memoria.Validation.FluentValidation](https://www.nuget.org/packages/Memoria.Validation.FluentValidation)                                           | [![Nuget Package](https://img.shields.io/badge/nuget-1.0.0-blue.svg)](https://www.nuget.org/packages/Memoria.Validation.FluentValidation)                      |

--- a/src/Memoria.Messaging.RabbitMq.InMemory/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Memoria.Messaging.RabbitMq.InMemory/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Memoria.Messaging.RabbitMq.InMemory.Extensions;
+
+/// <summary>
+/// Provides extension methods for configuring Memoria with the in-memory RabbitMQ messaging provider.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the in-memory RabbitMQ messaging provider to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection to add the provider to.</param>
+    public static void AddMemoriaInMemoryRabbitMq(this IServiceCollection services)
+    {
+        var storage = new InMemoryRabbitMqStorage();
+        services.AddSingleton(storage);
+        services.Replace(ServiceDescriptor.Singleton<IMessagingProvider>(_ => new InMemoryRabbitMqMessagingProvider(storage)));
+    }
+
+    /// <summary>
+    /// Adds the in-memory RabbitMQ messaging provider to the service collection with a shared storage instance.
+    /// </summary>
+    /// <param name="services">The service collection to add the provider to.</param>
+    /// <param name="storage">The shared storage instance for test verification.</param>
+    public static void AddMemoriaInMemoryRabbitMq(this IServiceCollection services, InMemoryRabbitMqStorage storage)
+    {
+        services.AddSingleton(storage);
+        services.Replace(ServiceDescriptor.Singleton<IMessagingProvider>(_ => new InMemoryRabbitMqMessagingProvider(storage)));
+    }
+}

--- a/src/Memoria.Messaging.RabbitMq.InMemory/InMemoryRabbitMqMessagingProvider.cs
+++ b/src/Memoria.Messaging.RabbitMq.InMemory/InMemoryRabbitMqMessagingProvider.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using Memoria.Results;
+using Newtonsoft.Json;
+
+namespace Memoria.Messaging.RabbitMq.InMemory;
+
+/// <summary>
+/// Provides in-memory messaging functionality for testing and local development
+/// without requiring a RabbitMQ connection.
+/// </summary>
+public class InMemoryRabbitMqMessagingProvider(InMemoryRabbitMqStorage storage) : IMessagingProvider
+{
+    /// <summary>
+    /// Sends a message to the specified queue (stored in-memory).
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message, which must implement IQueueMessage.</typeparam>
+    /// <param name="message">The message to send.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating success or failure.</returns>
+    public Task<Result> SendQueueMessage<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : IQueueMessage
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(message.QueueName))
+            {
+                return Task.FromResult<Result>(new Failure(Title: "Queue name", Description: "Queue name cannot be null or empty"));
+            }
+
+            var inMemoryMessage = CreateInMemoryMessage(message, message.QueueName);
+            storage.AddMessage(inMemoryMessage);
+
+            return Task.FromResult(Result.Ok());
+        }
+        catch (Exception ex)
+        {
+            var tagList = new TagList { { "Operation description", "Sending queue message" } };
+            Activity.Current?.AddException(ex, tagList, DateTimeOffset.UtcNow);
+            return Task.FromResult<Result>(new Failure
+            (
+                Title: "Error",
+                Description: "There was an error when processing the request"
+            ));
+        }
+    }
+
+    /// <summary>
+    /// Sends a message to the specified topic (stored in-memory).
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message, which must implement ITopicMessage.</typeparam>
+    /// <param name="message">The message to send.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A result indicating success or failure.</returns>
+    public Task<Result> SendTopicMessage<TMessage>(TMessage message, CancellationToken cancellationToken = default) where TMessage : ITopicMessage
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(message.TopicName))
+            {
+                return Task.FromResult<Result>(new Failure(Title: "Topic name", Description: "Topic name cannot be null or empty"));
+            }
+
+            var inMemoryMessage = CreateInMemoryMessage(message, message.TopicName);
+            storage.AddMessage(inMemoryMessage);
+
+            return Task.FromResult(Result.Ok());
+        }
+        catch (Exception ex)
+        {
+            var tagList = new TagList { { "Operation description", "Sending topic message" } };
+            Activity.Current?.AddException(ex, tagList, DateTimeOffset.UtcNow);
+            return Task.FromResult<Result>(new Failure
+            (
+                Title: "Error",
+                Description: "There was an error when processing the request"
+            ));
+        }
+    }
+
+    private static InMemoryMessage CreateInMemoryMessage<TMessage>(TMessage message, string entityName) where TMessage : IMessage
+    {
+        var json = JsonConvert.SerializeObject(message);
+
+        var inMemoryMessage = new InMemoryMessage
+        {
+            EntityName = entityName,
+            MessageBody = json,
+            ContentType = "application/json",
+            MessageId = Guid.NewGuid().ToString(),
+            OriginalMessageType = message.GetType().FullName,
+            SentAt = DateTimeOffset.UtcNow
+        };
+
+        if (message.ScheduledEnqueueTimeUtc.HasValue)
+        {
+            inMemoryMessage.ScheduledEnqueueTime = message.ScheduledEnqueueTimeUtc.Value;
+        }
+
+        foreach (var property in message.Properties)
+        {
+            inMemoryMessage.ApplicationProperties[property.Key] = property.Value;
+        }
+
+        return inMemoryMessage;
+    }
+}

--- a/src/Memoria.Messaging.RabbitMq.InMemory/InMemoryRabbitMqStorage.cs
+++ b/src/Memoria.Messaging.RabbitMq.InMemory/InMemoryRabbitMqStorage.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using Newtonsoft.Json;
+
+namespace Memoria.Messaging.RabbitMq.InMemory;
+
+/// <summary>
+/// Shared in-memory storage for RabbitMQ messaging implementation.
+/// This class provides thread-safe storage for sent messages, allowing test verification.
+/// </summary>
+public class InMemoryRabbitMqStorage
+{
+    private readonly ConcurrentBag<InMemoryMessage> _messages = [];
+
+    /// <summary>
+    /// Gets all stored messages.
+    /// </summary>
+    public IReadOnlyList<InMemoryMessage> GetMessages()
+    {
+        return _messages.ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Gets all stored messages for a specific entity (queue or topic name).
+    /// </summary>
+    public IEnumerable<InMemoryMessage> GetMessagesForEntity(string entityName)
+    {
+        return _messages.Where(m => string.Equals(m.EntityName, entityName, StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    /// <summary>
+    /// Gets all stored messages that can be deserialized to the specified type.
+    /// </summary>
+    public IEnumerable<T> GetMessages<T>() where T : class
+    {
+        var targetTypeName = typeof(T).FullName;
+
+        return _messages
+            .Where(m => m.ContentType == "application/json")
+            .Where(m => m.OriginalMessageType == targetTypeName)
+            .Select(m =>
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<T>(m.MessageBody);
+                }
+                catch
+                {
+                    return null;
+                }
+            })
+            .Where(m => m != null)
+            .Cast<T>()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Gets all stored messages for a specific entity that can be deserialized to the specified type.
+    /// </summary>
+    public IEnumerable<T> GetMessagesForEntity<T>(string entityName) where T : class
+    {
+        var targetTypeName = typeof(T).FullName;
+
+        return _messages
+            .Where(m => string.Equals(m.EntityName, entityName, StringComparison.OrdinalIgnoreCase))
+            .Where(m => m.ContentType == "application/json")
+            .Where(m => m.OriginalMessageType == targetTypeName)
+            .Select(m =>
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<T>(m.MessageBody);
+                }
+                catch
+                {
+                    return null;
+                }
+            })
+            .Where(m => m != null)
+            .Cast<T>()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Gets the number of messages sent to a specific entity.
+    /// </summary>
+    public int GetMessageCountForEntity(string entityName)
+    {
+        return _messages.Count(m => string.Equals(m.EntityName, entityName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets the total number of stored messages.
+    /// </summary>
+    public int TotalMessageCount => _messages.Count;
+
+    /// <summary>
+    /// Adds a message to the storage.
+    /// </summary>
+    internal void AddMessage(InMemoryMessage message)
+    {
+        _messages.Add(message);
+    }
+
+    /// <summary>
+    /// Clears all stored data. Useful for test cleanup.
+    /// </summary>
+    public void Clear()
+    {
+        while (!_messages.IsEmpty)
+        {
+            _messages.TryTake(out _);
+        }
+    }
+}
+
+/// <summary>
+/// Represents a message captured by the in-memory RabbitMQ provider.
+/// </summary>
+public class InMemoryMessage
+{
+    public string EntityName { get; set; } = string.Empty;
+    public string MessageBody { get; set; } = string.Empty;
+    public string? ContentType { get; set; }
+    public string? MessageId { get; set; }
+    public DateTime? ScheduledEnqueueTime { get; set; }
+    public Dictionary<string, object> ApplicationProperties { get; set; } = new();
+    public string? OriginalMessageType { get; set; }
+    public DateTimeOffset SentAt { get; set; }
+}

--- a/src/Memoria.Messaging.RabbitMq.InMemory/Memoria.Messaging.RabbitMq.InMemory.csproj
+++ b/src/Memoria.Messaging.RabbitMq.InMemory/Memoria.Messaging.RabbitMq.InMemory.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Memoria\Memoria.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Features/CommandSenderWithPublishingTests.cs
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Features/CommandSenderWithPublishingTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Commands;
+using Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Messages;
+using Xunit;
+
+namespace Memoria.Messaging.RabbitMq.InMemory.Tests.Features;
+
+public class CommandSenderWithPublishingTests : TestBase
+{
+    [Fact]
+    public async Task SendAndPublish_ShouldPublishRabbitMqMessages()
+    {
+        var result = await Dispatcher.SendAndPublish(new DoSomething(Id: Guid.NewGuid(), Name: "Test message data"));
+
+        result.Should().NotBeNull();
+        result.CommandResult.IsSuccess.Should().BeTrue();
+
+        var sentMessages = Storage.GetMessages();
+        sentMessages.Should().HaveCount(1);
+
+        var sentMessage = sentMessages[0];
+        sentMessage.EntityName.Should().Be("test-queue");
+        sentMessage.ContentType.Should().Be("application/json");
+        sentMessage.MessageId.Should().NotBeNullOrEmpty();
+
+        var deserializedMessages = Storage.GetMessages<TestQueueMessage>().ToArray();
+        deserializedMessages.Should().HaveCount(1);
+
+        var deserializedMessage = deserializedMessages.First();
+        deserializedMessage.QueueName.Should().Be("test-queue");
+        deserializedMessage.TestData.Should().Be("Test message data");
+    }
+}

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Features/InMemoryRabbitMqMessagingProviderTests.cs
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Features/InMemoryRabbitMqMessagingProviderTests.cs
@@ -1,0 +1,246 @@
+using FluentAssertions;
+using Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Messages;
+using Xunit;
+
+namespace Memoria.Messaging.RabbitMq.InMemory.Tests.Features;
+
+public class InMemoryRabbitMqMessagingProviderTests
+{
+    private readonly InMemoryRabbitMqStorage _storage = new();
+
+    [Fact]
+    public async Task SendQueueMessage_WithValidMessage_ShouldSucceed()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage
+        {
+            QueueName = "test-queue",
+            TestData = "Test message data",
+            Properties = new Dictionary<string, object> { { "key1", "value1" } }
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        var sentMessages = _storage.GetMessages();
+        sentMessages.Should().HaveCount(1);
+
+        var sentMessage = sentMessages[0];
+        sentMessage.EntityName.Should().Be("test-queue");
+        sentMessage.ContentType.Should().Be("application/json");
+        sentMessage.MessageId.Should().NotBeNullOrEmpty();
+
+        var deserializedMessages = _storage.GetMessages<TestQueueMessage>().ToArray();
+        deserializedMessages.Should().HaveCount(1);
+
+        var deserializedMessage = deserializedMessages.First();
+        deserializedMessage.QueueName.Should().Be("test-queue");
+        deserializedMessage.TestData.Should().Be("Test message data");
+    }
+
+    [Fact]
+    public async Task SendTopicMessage_WithValidMessage_ShouldSucceed()
+    {
+        var provider = CreateProvider();
+        var message = new TestTopicMessage
+        {
+            TopicName = "test-topic",
+            TestData = "Test topic message",
+            Properties = new Dictionary<string, object>
+            {
+                { "MessageType", "TestEvent" },
+                { "Version", 1 }
+            }
+        };
+
+        var result = await provider.SendTopicMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        var topicMessages = _storage.GetMessagesForEntity("test-topic");
+        topicMessages.Should().HaveCount(1);
+
+        _storage.GetMessageCountForEntity("test-topic").Should().Be(1);
+        _storage.TotalMessageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendQueueMessage_WithEmptyQueueName_ShouldReturnFailure()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage
+        {
+            QueueName = string.Empty,
+            TestData = "Test data"
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().NotBeNull();
+        result.Failure!.Title.Should().Be("Queue name");
+        result.Failure.Description.Should().Be("Queue name cannot be null or empty");
+
+        _storage.TotalMessageCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SendTopicMessage_WithEmptyTopicName_ShouldReturnFailure()
+    {
+        var provider = CreateProvider();
+        var message = new TestTopicMessage
+        {
+            TopicName = string.Empty,
+            TestData = "Test data"
+        };
+
+        var result = await provider.SendTopicMessage(message);
+
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().NotBeNull();
+        result.Failure!.Title.Should().Be("Topic name");
+        result.Failure.Description.Should().Be("Topic name cannot be null or empty");
+    }
+
+    [Fact]
+    public async Task SendQueueMessage_WithScheduledEnqueueTime_ShouldPreserveScheduledTime()
+    {
+        var provider = CreateProvider();
+        var scheduledTime = DateTime.UtcNow.AddHours(1);
+        var message = new TestQueueMessage
+        {
+            QueueName = "scheduled-queue",
+            TestData = "Scheduled message",
+            ScheduledEnqueueTimeUtc = scheduledTime
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var sentMessages = _storage.GetMessages();
+        sentMessages.Should().HaveCount(1);
+
+        var sentMessage = sentMessages.First();
+        sentMessage.ScheduledEnqueueTime.Should().NotBeNull();
+        sentMessage.ScheduledEnqueueTime!.Value.Should().BeCloseTo(scheduledTime, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task SendQueueMessage_WithApplicationProperties_ShouldPreserveProperties()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage
+        {
+            QueueName = "properties-queue",
+            TestData = "Message with properties",
+            Properties = new Dictionary<string, object>
+            {
+                { "CustomProperty1", "Value1" },
+                { "CustomProperty2", 42 },
+                { "CustomProperty3", true }
+            }
+        };
+
+        var result = await provider.SendQueueMessage(message);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var sentMessages = _storage.GetMessages();
+        var sentMessage = sentMessages.First();
+
+        sentMessage.ApplicationProperties.Should().HaveCount(3);
+        sentMessage.ApplicationProperties["CustomProperty1"].Should().Be("Value1");
+        sentMessage.ApplicationProperties["CustomProperty2"].Should().Be(42);
+        sentMessage.ApplicationProperties["CustomProperty3"].Should().Be(true);
+    }
+
+    [Fact]
+    public async Task SendMultipleMessages_ShouldCaptureAllMessages()
+    {
+        var provider = CreateProvider();
+        var queueMessage1 = new TestQueueMessage { QueueName = "queue1", TestData = "Queue message 1" };
+        var queueMessage2 = new TestQueueMessage { QueueName = "queue2", TestData = "Queue message 2" };
+        var topicMessage = new TestTopicMessage { TopicName = "topic1", TestData = "Topic message 1" };
+
+        await provider.SendQueueMessage(queueMessage1);
+        await provider.SendQueueMessage(queueMessage2);
+        await provider.SendTopicMessage(topicMessage);
+
+        _storage.TotalMessageCount.Should().Be(3);
+        _storage.GetMessageCountForEntity("queue1").Should().Be(1);
+        _storage.GetMessageCountForEntity("queue2").Should().Be(1);
+        _storage.GetMessageCountForEntity("topic1").Should().Be(1);
+
+        var allQueueMessages = _storage.GetMessages<TestQueueMessage>();
+        allQueueMessages.Should().HaveCount(2);
+
+        var allTopicMessages = _storage.GetMessages<TestTopicMessage>();
+        allTopicMessages.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Clear_ShouldRemoveAllStoredMessages()
+    {
+        var provider = CreateProvider();
+        var message = new TestQueueMessage { QueueName = "test-queue", TestData = "Test" };
+
+        await provider.SendQueueMessage(message);
+        _storage.TotalMessageCount.Should().Be(1);
+
+        _storage.Clear();
+
+        _storage.TotalMessageCount.Should().Be(0);
+        _storage.GetMessages().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMessagesByType_ShouldReturnOnlyMatchingType()
+    {
+        var provider = CreateProvider();
+        var queueMessage = new TestQueueMessage { QueueName = "queue1", TestData = "Queue data" };
+        var topicMessage = new TestTopicMessage { TopicName = "topic1", TestData = "Topic data" };
+
+        await provider.SendQueueMessage(queueMessage);
+        await provider.SendTopicMessage(topicMessage);
+
+        _storage.TotalMessageCount.Should().Be(2);
+
+        var queueMessages = _storage.GetMessages<TestQueueMessage>().ToArray();
+        queueMessages.Should().HaveCount(1);
+        queueMessages.First().TestData.Should().Be("Queue data");
+
+        var topicMessages = _storage.GetMessages<TestTopicMessage>().ToArray();
+        topicMessages.Should().HaveCount(1);
+        topicMessages.First().TestData.Should().Be("Topic data");
+    }
+
+    [Fact]
+    public async Task GetMessagesForEntity_ByType_ShouldReturnOnlyMatchingEntityAndType()
+    {
+        var provider = CreateProvider();
+        var message1 = new TestQueueMessage { QueueName = "queue1", TestData = "Message 1" };
+        var message2 = new TestQueueMessage { QueueName = "queue2", TestData = "Message 2" };
+
+        await provider.SendQueueMessage(message1);
+        await provider.SendQueueMessage(message2);
+
+        var queue1Messages = _storage.GetMessagesForEntity<TestQueueMessage>("queue1").ToArray();
+        queue1Messages.Should().HaveCount(1);
+        queue1Messages.First().TestData.Should().Be("Message 1");
+
+        var queue2Messages = _storage.GetMessagesForEntity<TestQueueMessage>("queue2").ToArray();
+        queue2Messages.Should().HaveCount(1);
+        queue2Messages.First().TestData.Should().Be("Message 2");
+    }
+
+    private InMemoryRabbitMqMessagingProvider CreateProvider()
+    {
+        return new InMemoryRabbitMqMessagingProvider(_storage);
+    }
+}

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Memoria.Messaging.RabbitMq.InMemory.Tests.csproj
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Memoria.Messaging.RabbitMq.InMemory.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="7.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Memoria.Messaging.RabbitMq.InMemory\Memoria.Messaging.RabbitMq.InMemory.csproj" />
+      <ProjectReference Include="..\..\src\Memoria\Memoria.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Commands/DoSomething.cs
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Commands/DoSomething.cs
@@ -1,0 +1,5 @@
+using Memoria.Commands;
+
+namespace Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Commands;
+
+public record DoSomething(Guid Id, string Name) : ICommand<CommandResponse>;

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Commands/Handlers/DoSomethingHandler.cs
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Commands/Handlers/DoSomethingHandler.cs
@@ -1,0 +1,27 @@
+using Memoria.Commands;
+using Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Messages;
+using Memoria.Results;
+
+namespace Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Commands.Handlers;
+
+public class DoSomethingHandler : ICommandHandler<DoSomething, CommandResponse>
+{
+    public async Task<Result<CommandResponse>> Handle(DoSomething command, CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+
+        var queueMessage = new TestQueueMessage
+        {
+            TestData = command.Name,
+            QueueName = "test-queue",
+            Properties = new Dictionary<string, object> { { "CommandId", command.Id } }
+        };
+
+        var response = new CommandResponse(
+            queueMessage,
+            new { Message = $"Successfully processed command for: {command.Name}" }
+        );
+
+        return response;
+    }
+}

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Messages/TestQueueMessage.cs
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Messages/TestQueueMessage.cs
@@ -1,0 +1,9 @@
+namespace Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Messages;
+
+public class TestQueueMessage : IQueueMessage
+{
+    public string QueueName { get; set; } = string.Empty;
+    public DateTime? ScheduledEnqueueTimeUtc { get; set; }
+    public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+    public string TestData { get; set; } = string.Empty;
+}

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Messages/TestTopicMessage.cs
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/Models/Messages/TestTopicMessage.cs
@@ -1,0 +1,9 @@
+namespace Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Messages;
+
+public class TestTopicMessage : ITopicMessage
+{
+    public string TopicName { get; set; } = string.Empty;
+    public DateTime? ScheduledEnqueueTimeUtc { get; set; }
+    public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+    public string TestData { get; set; } = string.Empty;
+}

--- a/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/TestBase.cs
+++ b/tests/Memoria.Messaging.RabbitMq.InMemory.Tests/TestBase.cs
@@ -1,0 +1,31 @@
+using Memoria.Commands;
+using Memoria.Messaging.RabbitMq.InMemory;
+using Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Commands;
+using Memoria.Messaging.RabbitMq.InMemory.Tests.Models.Commands.Handlers;
+using Memoria.Notifications;
+using Memoria.Queries;
+using Memoria.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Memoria.Messaging.RabbitMq.InMemory.Tests;
+
+public abstract class TestBase
+{
+    protected readonly InMemoryRabbitMqStorage Storage;
+    protected readonly IDispatcher Dispatcher;
+
+    protected TestBase()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<DoSomething, CommandResponse>, DoSomethingHandler>()
+            .BuildServiceProvider();
+
+        Storage = new InMemoryRabbitMqStorage();
+        var messagingProvider = new InMemoryRabbitMqMessagingProvider(Storage);
+        var messagePublisher = new MessagePublisher(messagingProvider);
+        var commandSender = new CommandSender(serviceProvider, Substitute.For<IValidationService>(), Substitute.For<INotificationPublisher>(), messagePublisher);
+
+        Dispatcher = new Dispatcher(commandSender, Substitute.For<IQueryProcessor>(), Substitute.For<INotificationPublisher>());
+    }
+}


### PR DESCRIPTION
Introduce Memoria.Messaging.RabbitMq.InMemory, an in-memory implementation of IMessagingProvider that enables testing and local development without a RabbitMQ connection. Follows the same pattern as the in-memory Service Bus and Cosmos providers.

Also update README roadmap and NuGet packages table.