### PR TITLE
179 event type versioning

### DIFF
--- a/src/Memoria.EventSourcing/Domain/TypeBindings.cs
+++ b/src/Memoria.EventSourcing/Domain/TypeBindings.cs
@@ -22,4 +22,10 @@ public static class TypeBindings
     /// <param name="version">The version.</param>
     /// <returns>The binding key.</returns>
     public static string GetTypeBindingKey(string name, int version) => $"{name}:{version}";
+
+    // public static string GetEventTypeBindingKey(Type type)
+    // {
+    //     var test = EventTypeBindings.
+    //     return $"{name}:{version}";
+    // }
 }

--- a/src/Memoria.EventSourcing/Domain/TypeBindings.cs
+++ b/src/Memoria.EventSourcing/Domain/TypeBindings.cs
@@ -22,10 +22,4 @@ public static class TypeBindings
     /// <param name="version">The version.</param>
     /// <returns>The binding key.</returns>
     public static string GetTypeBindingKey(string name, int version) => $"{name}:{version}";
-
-    // public static string GetEventTypeBindingKey(Type type)
-    // {
-    //     var test = EventTypeBindings.
-    //     return $"{name}:{version}";
-    // }
 }

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetAEventsTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetAEventsTests.cs
@@ -1,3 +1,3 @@
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.Features.DomainService;
 
-public class GetEventsTests() : Store.Tests.Features.GetAggregateTests(new DomainServiceFactory());
+public class GetEventsTests() : Store.Tests.Features.GetAggregateTests(new InMemoryCosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetAggregateTests.cs
@@ -1,3 +1,3 @@
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.Features.DomainService;
 
-public class GetAggregateTests() : Store.Tests.Features.GetAggregateTests(new DomainServiceFactory());
+public class GetAggregateTests() : Store.Tests.Features.GetAggregateTests(new InMemoryCosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetEventsAppliedToAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetEventsAppliedToAggregateTests.cs
@@ -1,3 +1,4 @@
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.Features.DomainService;
 
-public class GetEventsAppliedToAggregateTests() : Store.Tests.Features.GetEventsAppliedToAggregateTests(new DomainServiceFactory());
+public class GetEventsAppliedToAggregateTests()
+    : Store.Tests.Features.GetEventsAppliedToAggregateTests(new InMemoryCosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetInMemoryAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetInMemoryAggregateTests.cs
@@ -1,3 +1,4 @@
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.Features.DomainService;
 
-public class GetInMemoryAggregateTests() : Store.Tests.Features.GetInMemoryAggregateTests(new DomainServiceFactory());
+public class GetInMemoryAggregateTests()
+    : Store.Tests.Features.GetInMemoryAggregateTests(new InMemoryCosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetLatestEventSequenceTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/GetLatestEventSequenceTests.cs
@@ -1,3 +1,4 @@
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.Features.DomainService;
 
-public class GetLatestEventSequenceTests() : Store.Tests.Features.GetLatestEventSequenceTests(new DomainServiceFactory());
+public class GetLatestEventSequenceTests()
+    : Store.Tests.Features.GetLatestEventSequenceTests(new InMemoryCosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/SaveAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/SaveAggregateTests.cs
@@ -1,3 +1,3 @@
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.Features.DomainService;
 
-public class SaveAggregateTests() : Store.Tests.Features.SaveAggregateTests(new DomainServiceFactory());
+public class SaveAggregateTests() : Store.Tests.Features.SaveAggregateTests(new InMemoryCosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/UpdateAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/Features/DomainService/UpdateAggregateTests.cs
@@ -1,3 +1,4 @@
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests.Features.DomainService;
 
-public class UpdateAggregateTests() : Store.Tests.Features.UpdateAggregateTests(new DomainServiceFactory());
+public class UpdateAggregateTests()
+    : Store.Tests.Features.UpdateAggregateTests(new InMemoryCosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/InMemoryCosmosDomainServiceFactory.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.InMemory.Tests/InMemoryCosmosDomainServiceFactory.cs
@@ -4,8 +4,9 @@ using Microsoft.Extensions.Time.Testing;
 
 namespace Memoria.EventSourcing.Store.Cosmos.InMemory.Tests;
 
-public class DomainServiceFactory : IDomainServiceFactory
+public class InMemoryCosmosDomainServiceFactory : IDomainServiceFactory
 {
-    public IDomainService CreateDomainService(FakeTimeProvider timeProvider, IHttpContextAccessor httpContextAccessor) =>
+    public IDomainService
+        CreateDomainService(FakeTimeProvider timeProvider, IHttpContextAccessor httpContextAccessor) =>
         new InMemoryCosmosDomainService(new InMemoryCosmosStorage(), timeProvider, httpContextAccessor);
 }

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/CosmosDomainServiceFactory.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/CosmosDomainServiceFactory.cs
@@ -7,7 +7,7 @@ using NSubstitute;
 
 namespace Memoria.EventSourcing.Store.Cosmos.Tests;
 
-public class DomainServiceFactory : IDomainServiceFactory
+public class CosmosDomainServiceFactory : IDomainServiceFactory
 {
     public IDomainService CreateDomainService(FakeTimeProvider timeProvider, IHttpContextAccessor httpContextAccessor)
     {

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetAEventsTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetAEventsTests.cs
@@ -1,3 +1,3 @@
 namespace Memoria.EventSourcing.Store.Cosmos.Tests.Features.DomainService;
 
-public class GetEventsTests() : Store.Tests.Features.GetAggregateTests(new DomainServiceFactory());
+public class GetEventsTests() : Store.Tests.Features.GetAggregateTests(new CosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetAggregateTests.cs
@@ -1,3 +1,3 @@
 namespace Memoria.EventSourcing.Store.Cosmos.Tests.Features.DomainService;
 
-public class GetAggregateTests() : Store.Tests.Features.GetAggregateTests(new DomainServiceFactory());
+public class GetAggregateTests() : Store.Tests.Features.GetAggregateTests(new CosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetEventsAppliedToAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetEventsAppliedToAggregateTests.cs
@@ -1,3 +1,4 @@
 namespace Memoria.EventSourcing.Store.Cosmos.Tests.Features.DomainService;
 
-public class GetEventsAppliedToAggregateTests() : Store.Tests.Features.GetEventsAppliedToAggregateTests(new DomainServiceFactory());
+public class GetEventsAppliedToAggregateTests()
+    : Store.Tests.Features.GetEventsAppliedToAggregateTests(new CosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetInMemoryAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetInMemoryAggregateTests.cs
@@ -1,3 +1,4 @@
 namespace Memoria.EventSourcing.Store.Cosmos.Tests.Features.DomainService;
 
-public class GetInMemoryAggregateTests() : Store.Tests.Features.GetInMemoryAggregateTests(new DomainServiceFactory());
+public class GetInMemoryAggregateTests()
+    : Store.Tests.Features.GetInMemoryAggregateTests(new CosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetLatestEventSequenceTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/GetLatestEventSequenceTests.cs
@@ -1,3 +1,4 @@
 namespace Memoria.EventSourcing.Store.Cosmos.Tests.Features.DomainService;
 
-public class GetLatestEventSequenceTests() : Store.Tests.Features.GetLatestEventSequenceTests(new DomainServiceFactory());
+public class GetLatestEventSequenceTests()
+    : Store.Tests.Features.GetLatestEventSequenceTests(new CosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/SaveAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/SaveAggregateTests.cs
@@ -1,3 +1,3 @@
 namespace Memoria.EventSourcing.Store.Cosmos.Tests.Features.DomainService;
 
-public class SaveAggregateTests() : Store.Tests.Features.SaveAggregateTests(new DomainServiceFactory());
+public class SaveAggregateTests() : Store.Tests.Features.SaveAggregateTests(new CosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/UpdateAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Cosmos.Tests/Features/DomainService/UpdateAggregateTests.cs
@@ -1,3 +1,3 @@
 namespace Memoria.EventSourcing.Store.Cosmos.Tests.Features.DomainService;
 
-public class UpdateAggregateTests() : Store.Tests.Features.UpdateAggregateTests(new DomainServiceFactory());
+public class UpdateAggregateTests() : Store.Tests.Features.UpdateAggregateTests(new CosmosDomainServiceFactory());

--- a/tests/Memoria.EventSourcing.Store.Tests/Features/UpdateAggregateTests.cs
+++ b/tests/Memoria.EventSourcing.Store.Tests/Features/UpdateAggregateTests.cs
@@ -68,5 +68,33 @@ public abstract class UpdateAggregateTests(IDomainServiceFactory domainServiceFa
             updatedAggregateResult.Value.Description.Should().Be("Updated Description");
         }
     }
+    
+    [Fact]
+    public async Task GivenEventWithNewVersion_WhenAggregateIsUpdated_ThenNewEventVersionIsApplied()
+    {
+        var id = Guid.NewGuid().ToString();
+        var streamId = new TestStreamId(id);
+        var aggregateId = new TestAggregate1Id(id);
+        var aggregate = new TestAggregate1(id, "Test Name", "Test Description");
+
+        await DomainService.SaveAggregate(streamId, aggregateId, aggregate, expectedEventSequence: 0);
+        await DomainService.SaveEvents(streamId, [new SomethingHappenedEvent2("Something 2")], expectedEventSequence: 1);
+        var updatedAggregateResult = await DomainService.UpdateAggregate(streamId, aggregateId);
+
+        using (new AssertionScope())
+        {
+            updatedAggregateResult.IsSuccess.Should().BeTrue();
+
+            updatedAggregateResult.Value.Should().NotBeNull();
+
+            updatedAggregateResult.Value.StreamId.Should().Be(streamId.Id);
+            updatedAggregateResult.Value.AggregateId.Should().Be(aggregateId.ToStoreId());
+            updatedAggregateResult.Value.Version.Should().Be(2);
+
+            updatedAggregateResult.Value.Id.Should().Be(id);
+            updatedAggregateResult.Value.Name.Should().Be("Something 2");
+            updatedAggregateResult.Value.Description.Should().Be("Test Description");
+        }
+    }
 }
 

--- a/tests/Memoria.EventSourcing.Store.Tests/Models/Aggregates/TestAggregate1.cs
+++ b/tests/Memoria.EventSourcing.Store.Tests/Models/Aggregates/TestAggregate1.cs
@@ -10,7 +10,8 @@ public class TestAggregate1 : AggregateRoot
     [
         typeof(TestAggregateCreatedEvent),
         typeof(TestAggregateUpdatedEvent),
-        typeof(SomethingHappenedEvent)
+        typeof(SomethingHappenedEvent),
+        typeof(SomethingHappenedEvent2)
     ];
 
     public string Id { get; set; } = null!;
@@ -37,6 +38,7 @@ public class TestAggregate1 : AggregateRoot
         {
             TestAggregateCreatedEvent testAggregateCreated => Apply(testAggregateCreated),
             TestAggregateUpdatedEvent testAggregateUpdated => Apply(testAggregateUpdated),
+            SomethingHappenedEvent2 somethingHappened2 => Apply(somethingHappened2),
             _ => false
         };
     }
@@ -55,6 +57,13 @@ public class TestAggregate1 : AggregateRoot
         Name = @event.Name;
         Description = @event.Description;
 
+        return true;
+    }
+
+    private bool Apply(SomethingHappenedEvent2 @event)
+    {
+        Name = @event.Something2;
+        
         return true;
     }
 }

--- a/tests/Memoria.EventSourcing.Store.Tests/Models/Events/SomethingHappenedEvent.cs
+++ b/tests/Memoria.EventSourcing.Store.Tests/Models/Events/SomethingHappenedEvent.cs
@@ -4,3 +4,6 @@ namespace Memoria.EventSourcing.Store.Tests.Models.Events;
 
 [EventType("SomethingHappened")]
 public record SomethingHappenedEvent(string Something) : IEvent;
+
+[EventType("SomethingHappened", version: 2)]
+public record SomethingHappenedEvent2(string Something2) : IEvent;

--- a/tests/Memoria.EventSourcing.Store.Tests/TestBase.cs
+++ b/tests/Memoria.EventSourcing.Store.Tests/TestBase.cs
@@ -32,15 +32,16 @@ public abstract class TestBase : IDisposable
     {
         TypeBindings.EventTypeBindings = new Dictionary<string, Type>
         {
-            {"TestAggregateCreated:1", typeof(TestAggregateCreatedEvent)},
-            {"TestAggregateUpdated:1", typeof(TestAggregateUpdatedEvent)},
-            {"SomethingHappened:1", typeof(SomethingHappenedEvent)}
+            { "TestAggregateCreated:1", typeof(TestAggregateCreatedEvent) },
+            { "TestAggregateUpdated:1", typeof(TestAggregateUpdatedEvent) },
+            { "SomethingHappened:1", typeof(SomethingHappenedEvent) },
+            { "SomethingHappened:2", typeof(SomethingHappenedEvent2) }
         };
 
         TypeBindings.AggregateTypeBindings = new Dictionary<string, Type>
         {
-            {"TestAggregate1:1", typeof(TestAggregate1)},
-            {"TestAggregate2:1", typeof(TestAggregate2)}
+            { "TestAggregate1:1", typeof(TestAggregate1) },
+            { "TestAggregate2:1", typeof(TestAggregate2) }
         };
     }
 
@@ -70,7 +71,8 @@ public abstract class TestBase : IDisposable
         _activityListener = new ActivityListener();
         _activityListener.ShouldListenTo = _ => true;
         _activityListener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
-        _activityListener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData;
+        _activityListener.SampleUsingParentId =
+            (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData;
         _activityListener.ActivityStarted = _ => { };
         _activityListener.ActivityStopped = _ => { };
 


### PR DESCRIPTION
This pull request refactors the test infrastructure for Cosmos and in-memory event sourcing stores, and introduces support for event versioning in aggregate handling. The main changes include renaming and updating factory classes for clarity, updating test classes to use the new factories, and adding a new event version along with corresponding aggregate logic and tests to ensure correct handling of event versioning.

**Test Infrastructure Refactoring:**

* Renamed `DomainServiceFactory` to `InMemoryCosmosDomainServiceFactory` in the in-memory test project and updated all related test classes to use this new factory, improving clarity and consistency. [[1]](diffhunk://#diff-b8765edbad6f871e71bb60f5f8a9babcd4bbb4f1a8f2bfac2cba6e9df52f02ffL7-R10) [[2]](diffhunk://#diff-40fd51ba7bff5288eaf220a154efcfb5c8c117360aa68ba2b25a377d65c7de7fL3-R3) [[3]](diffhunk://#diff-6d5954376d9afa073283e090bfc598d620e1377ef28a8e91281ca4c35818f9b7L3-R3) [[4]](diffhunk://#diff-623c44a9d0d4eaf62f248f0a13eb59d67f8ecbd994ffc442f73213e40643b953L3-R4) [[5]](diffhunk://#diff-50a8c468f406ce136d44df68cd0f5a810113f58847c8b250136e6719aad7d689L3-R4) [[6]](diffhunk://#diff-4c9643533c6643681a5a8216aab0382add16ab80766cd6806fc6712b6c8e5ae6L3-R4) [[7]](diffhunk://#diff-c247405d443ea8d71965cfb7be2bd732cf334dd7d27eef19b19d2d2322786e81L3-R3) [[8]](diffhunk://#diff-46604b0f8f99f43ad59d48e0b54e4b05ee6fb62efb243e853c2872eb2580105bL3-R4)
* Renamed `DomainServiceFactory` to `CosmosDomainServiceFactory` in the Cosmos test project and updated all related test classes to use this new factory. [[1]](diffhunk://#diff-cda28022df2784d3f286653bf6870e17fd69a32fa1bb9f020ec33d0cc0c959a0L10-R10) [[2]](diffhunk://#diff-f76e69e4323b9a903defd23d924f5f8399378da09c8ab20cf6cb8971c2394852L3-R3) [[3]](diffhunk://#diff-99fdf1c5f58f47793e5c6269c60698786c4f9e48a7ab84c3ba118df33ed31a6bL3-R3) [[4]](diffhunk://#diff-89eb9ae343db7d8fc8c73cadaf2cdbf5ce251e35b32f9a6d9138be920bc04772L3-R4) [[5]](diffhunk://#diff-728b0264e485032ce1092f9dcd5196c390c127513acc72727abf31d9f7c1fabfL3-R4) [[6]](diffhunk://#diff-ba33204ff53b639dabd2fb18d9c1eae32f253bfdd48eda0ab859931237401af0L3-R4) [[7]](diffhunk://#diff-babeed1669c2c09701b70ffbdb3b9d12051892161ab2e02495b358e4e9e756a2L3-R3) [[8]](diffhunk://#diff-a0a8606141d802bae536c7395ec8c727a36974d1dbaf095b90ed3874867552f2L3-R3)

**Event Versioning Support:**

* Added a new event type `SomethingHappenedEvent2` with version 2, and updated `TestAggregate1` to handle this new event version in its `Apply` logic. [[1]](diffhunk://#diff-45dd63b3269da3632101403c682e4e9e47e7df6ee2569924c86e1bada3f6684dR7-R9) [[2]](diffhunk://#diff-11a055ba17df74c4fa390ac44c15172711ed74a7e8a9a9ee4536266b0fb9340cL13-R14) [[3]](diffhunk://#diff-11a055ba17df74c4fa390ac44c15172711ed74a7e8a9a9ee4536266b0fb9340cR41) [[4]](diffhunk://#diff-11a055ba17df74c4fa390ac44c15172711ed74a7e8a9a9ee4536266b0fb9340cR62-R68)

**Testing Event Versioning:**

* Added a new test `GivenEventWithNewVersion_WhenAggregateIsUpdated_ThenNewEventVersionIsApplied` to verify that aggregates correctly apply new event versions when updating.

**Minor/Other:**

* Added a commented-out stub for a potential `GetEventTypeBindingKey` method in `TypeBindings.cs` (no functional change).