### PR TITLE
feat: add pipeline behaviors

### DIFF
--- a/docs/guides/pipeline-behaviors.md
+++ b/docs/guides/pipeline-behaviors.md
@@ -1,0 +1,148 @@
+# Pipeline behaviors
+
+Pipeline behaviors wrap command and query handling so you can add cross-cutting concerns — logging, timing, authorization, transactions — without touching individual handlers.
+
+A behavior implements `IPipelineBehavior<TRequest, TResponse>` (for `ICommand<TResponse>` and `IQuery<TResult>`) or `IPipelineBehavior<TRequest>` (for `ICommand` with no response). It receives the request and a `next` continuation. Calling `next()` runs the next behavior or — if this is the innermost one — the terminal handler.
+
+## Define a behavior
+
+```C#
+using Memoria.Pipeline;
+using Memoria.Results;
+
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly ILogger<LoggingBehavior<TRequest, TResponse>> logger;
+
+    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger) => this.logger = logger;
+
+    public async Task<Result<TResponse>> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", typeof(TRequest).Name);
+        var result = await next();
+        logger.LogInformation("Handled {Request}: success={Success}", typeof(TRequest).Name, result.IsSuccess);
+        return result;
+    }
+}
+```
+
+## Register it
+
+```C#
+services.AddMemoria(typeof(Program));
+services.AddMemoriaBehavior(typeof(LoggingBehavior<,>));   // open generic
+services.AddMemoriaBehavior<MyClosedBehavior>();           // closed generic
+```
+
+Behaviors are **opt-in**. `AddMemoria(...)` does not auto-discover them — you register each one explicitly.
+
+## Ordering
+
+Behaviors run in **registration order**, with the first registered behavior wrapping the outermost layer:
+
+```C#
+services.AddMemoriaBehavior(typeof(LoggingBehavior<,>));
+services.AddMemoriaBehavior(typeof(TimingBehavior<,>));
+```
+
+Produces this call order around the handler:
+
+```
+Logging:enter → Timing:enter → handler → Timing:exit → Logging:exit
+```
+
+## Short-circuit by returning a Failure
+
+Skip the rest of the pipeline by returning a `Result` without calling `next()`. The handler never runs.
+
+```C#
+public class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public Task<Result<TResponse>> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (!CurrentUserIsAuthorized(request))
+        {
+            return Task.FromResult(Result<TResponse>.Fail(title: "Forbidden"));
+        }
+        return next();
+    }
+}
+```
+
+This is the idiomatic precondition pattern in Memoria — no exceptions, just a `Failure` propagated through the `Result` type. See [Result pattern](../concepts/result-pattern.md).
+
+## Sample: timing
+
+```C#
+public class TimingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly ILogger<TimingBehavior<TRequest, TResponse>> logger;
+
+    public TimingBehavior(ILogger<TimingBehavior<TRequest, TResponse>> logger) => this.logger = logger;
+
+    public async Task<Result<TResponse>> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            return await next();
+        }
+        finally
+        {
+            logger.LogInformation("{Request} took {Ms}ms", typeof(TRequest).Name, sw.ElapsedMilliseconds);
+        }
+    }
+}
+```
+
+## Sample: unit of work
+
+Commit `DbContext` changes only after the handler succeeds. The `Result` makes the rollback path explicit — no exception-driven control flow.
+
+```C#
+public class UnitOfWorkBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : ICommand<TResponse>
+{
+    private readonly MyDbContext db;
+
+    public UnitOfWorkBehavior(MyDbContext db) => this.db = db;
+
+    public async Task<Result<TResponse>> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var result = await next();
+        if (result.IsSuccess)
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        return result;
+    }
+}
+```
+
+## What pipeline behaviors don't cover (yet)
+
+- **Notifications** — `INotification` fan-out is not wrapped. Wrapping a single behavior around N handlers has ambiguous semantics; this may change in a future release.
+- **Command sequences** — each step in an `ICommandSequence` runs without per-step behaviors. Dispatch each command individually through the dispatcher if you need behaviors per command.
+- **Validation and caching** — Memoria has dedicated, longer-standing mechanisms for these: pass `validateCommand: true` to opt in, or inherit from `CacheableQuery<T>`. They are not implemented as pipeline behaviors today. See [Validate commands](validate-commands.md) and [Cache query results](cache-queries.md).
+
+## Related
+
+- [Result pattern](../concepts/result-pattern.md)
+- [Quickstart: Mediator](../getting-started/quickstart-mediator.md)
+- [Validate commands](validate-commands.md)
+- [Cache query results](cache-queries.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ Memoria is a .NET framework that can be used as a simple mediator or as an Event
 ### Guides
 
 - [Validate commands](guides/validate-commands.md)
+- [Add pipeline behaviors](guides/pipeline-behaviors.md)
 - [Use a custom command handler](guides/custom-command-handlers.md)
 - [Run a sequence of commands](guides/command-sequences.md)
 - [Publish to Service Bus](guides/publish-to-service-bus.md) · [Publish to RabbitMQ](guides/publish-to-rabbitmq.md)

--- a/src/Memoria/Commands/CommandHandlerWrapper.cs
+++ b/src/Memoria/Commands/CommandHandlerWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Memoria.Results;
+using Memoria.Pipeline;
+using Memoria.Results;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Memoria.Commands;
@@ -13,7 +14,18 @@ internal class CommandHandlerWrapper<TCommand, TResponse> : CommandHandlerWrappe
             throw new InvalidOperationException($"Command handler for {typeof(ICommand<TResponse>).Name} not found.");
         }
 
-        return await handler.Handle((TCommand)command, cancellationToken);
+        var typedCommand = (TCommand)command;
+        RequestHandlerDelegate<TResponse> pipeline = () => handler.Handle(typedCommand, cancellationToken);
+
+        var behaviors = serviceProvider.GetServices<IPipelineBehavior<TCommand, TResponse>>().Reverse().ToArray();
+        foreach (var behavior in behaviors)
+        {
+            var next = pipeline;
+            var current = behavior;
+            pipeline = () => current.Handle(typedCommand, next, cancellationToken);
+        }
+
+        return await pipeline();
     }
 }
 

--- a/src/Memoria/Commands/CommandSender.cs
+++ b/src/Memoria/Commands/CommandSender.cs
@@ -2,6 +2,7 @@
 using System.Linq.Expressions;
 using Memoria.Messaging;
 using Memoria.Notifications;
+using Memoria.Pipeline;
 using Memoria.Results;
 using Memoria.Validation;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,7 +59,7 @@ public class CommandSender(IServiceProvider serviceProvider, IValidationService 
             throw new InvalidOperationException($"Command handler for {typeof(TCommand).Name} not found.");
         }
 
-        return await commandHandler.Handle(command, cancellationToken);
+        return await InvokeWithPipeline(command, () => commandHandler.Handle(command, cancellationToken), cancellationToken);
     }
 
     /// <summary>
@@ -84,7 +85,21 @@ public class CommandSender(IServiceProvider serviceProvider, IValidationService 
             }
         }
 
-        return await commandHandler();
+        return await InvokeWithPipeline(command, commandHandler, cancellationToken);
+    }
+
+    private async Task<Result> InvokeWithPipeline<TCommand>(TCommand command, Func<Task<Result>> terminal, CancellationToken cancellationToken)
+        where TCommand : ICommand
+    {
+        RequestHandlerDelegate pipeline = () => terminal();
+        var behaviors = serviceProvider.GetServices<IPipelineBehavior<TCommand>>().Reverse().ToArray();
+        foreach (var behavior in behaviors)
+        {
+            var next = pipeline;
+            var current = behavior;
+            pipeline = () => current.Handle(command, next, cancellationToken);
+        }
+        return await pipeline();
     }
 
     /// <summary>

--- a/src/Memoria/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Memoria/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Memoria.Commands;
 using Memoria.Messaging;
 using Memoria.Notifications;
+using Memoria.Pipeline;
 using Memoria.Queries;
 using Memoria.Validation;
 using Microsoft.Extensions.DependencyInjection;
@@ -44,6 +45,70 @@ public static class ServiceCollectionExtensions
 
         RegisterHandlers(services, types);
     }
+
+    /// <summary>
+    /// Registers a pipeline behavior. Behaviors run in registration order, with the first
+    /// registered behavior wrapping the outermost layer. The behavior type must implement
+    /// either <see cref="IPipelineBehavior{TRequest}"/> or <see cref="IPipelineBehavior{TRequest, TResponse}"/>.
+    /// Open generic behavior types are supported.
+    /// </summary>
+    /// <param name="services">The IServiceCollection to add services to.</param>
+    /// <param name="behaviorType">The behavior implementation type. May be an open generic.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">When <paramref name="services"/> or <paramref name="behaviorType"/> is null.</exception>
+    /// <exception cref="ArgumentException">When <paramref name="behaviorType"/> does not implement an IPipelineBehavior interface.</exception>
+    public static IServiceCollection AddMemoriaBehavior(this IServiceCollection services, Type behaviorType)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(behaviorType);
+
+        var matched = behaviorType.GetInterfaces()
+            .Where(i => i.IsGenericType && PipelineBehaviorOpenGenerics.Contains(i.GetGenericTypeDefinition()))
+            .ToList();
+
+        if (matched.Count == 0)
+        {
+            throw new ArgumentException(
+                $"{behaviorType.Name} does not implement IPipelineBehavior<TRequest> or IPipelineBehavior<TRequest, TResponse>.",
+                nameof(behaviorType));
+        }
+
+        if (behaviorType.IsGenericTypeDefinition)
+        {
+            foreach (var iface in matched)
+            {
+                services.AddScoped(iface.GetGenericTypeDefinition(), behaviorType);
+            }
+        }
+        else
+        {
+            foreach (var iface in matched)
+            {
+                services.AddScoped(iface, behaviorType);
+            }
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a pipeline behavior. Behaviors run in registration order, with the first
+    /// registered behavior wrapping the outermost layer.
+    /// </summary>
+    /// <typeparam name="TBehavior">The behavior implementation type.</typeparam>
+    /// <param name="services">The IServiceCollection to add services to.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+    public static IServiceCollection AddMemoriaBehavior<TBehavior>(this IServiceCollection services)
+        where TBehavior : class
+    {
+        return services.AddMemoriaBehavior(typeof(TBehavior));
+    }
+
+    private static readonly Type[] PipelineBehaviorOpenGenerics =
+    [
+        typeof(IPipelineBehavior<>),
+        typeof(IPipelineBehavior<,>),
+    ];
 
     private static void RegisterHandlers(IServiceCollection services, Type[] types)
     {

--- a/src/Memoria/Pipeline/IPipelineBehavior.cs
+++ b/src/Memoria/Pipeline/IPipelineBehavior.cs
@@ -1,0 +1,84 @@
+using Memoria.Commands;
+using Memoria.Results;
+
+namespace Memoria.Pipeline;
+
+/// <summary>
+/// Represents the continuation in a pipeline behavior chain for requests that produce no
+/// response value. Invoking it runs the next behavior, or the terminal handler if this is
+/// the innermost behavior.
+/// </summary>
+/// <returns>The <see cref="Result"/> produced by the inner step.</returns>
+public delegate Task<Result> RequestHandlerDelegate();
+
+/// <summary>
+/// Represents the continuation in a pipeline behavior chain. Invoking it runs the next
+/// behavior, or the terminal handler if this is the innermost behavior.
+/// </summary>
+/// <typeparam name="TResponse">The type of response produced by the inner step.</typeparam>
+/// <returns>The <see cref="Result{TResponse}"/> produced by the inner step.</returns>
+public delegate Task<Result<TResponse>> RequestHandlerDelegate<TResponse>();
+
+/// <summary>
+/// Defines a behavior that wraps the handling of a command that produces no response,
+/// enabling cross-cutting concerns such as logging, timing, authorization, or
+/// transactional boundaries.
+/// </summary>
+/// <typeparam name="TRequest">The command type the behavior applies to.</typeparam>
+public interface IPipelineBehavior<in TRequest>
+    where TRequest : ICommand
+{
+    /// <summary>
+    /// Handles the request, optionally invoking the next step in the pipeline. Returning
+    /// without calling <paramref name="next"/> short-circuits the chain.
+    /// </summary>
+    /// <param name="request">The request being handled.</param>
+    /// <param name="next">The continuation that invokes the next behavior or terminal handler.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A <see cref="Result"/> produced either by the chain or by this behavior directly.</returns>
+    Task<Result> Handle(
+        TRequest request,
+        RequestHandlerDelegate next,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Defines a behavior that wraps the handling of a request, enabling cross-cutting
+/// concerns such as logging, timing, authorization, or transactional boundaries.
+/// </summary>
+/// <typeparam name="TRequest">The request type the behavior applies to.</typeparam>
+/// <typeparam name="TResponse">The response type produced by the request.</typeparam>
+/// <example>
+/// <code>
+/// public class LoggingBehavior&lt;TRequest, TResponse&gt; : IPipelineBehavior&lt;TRequest, TResponse&gt;
+///     where TRequest : notnull
+/// {
+///     public async Task&lt;Result&lt;TResponse&gt;&gt; Handle(
+///         TRequest request,
+///         RequestHandlerDelegate&lt;TResponse&gt; next,
+///         CancellationToken cancellationToken)
+///     {
+///         // pre-processing
+///         var result = await next();
+///         // post-processing
+///         return result;
+///     }
+/// }
+/// </code>
+/// </example>
+public interface IPipelineBehavior<in TRequest, TResponse>
+    where TRequest : notnull
+{
+    /// <summary>
+    /// Handles the request, optionally invoking the next step in the pipeline. Returning
+    /// without calling <paramref name="next"/> short-circuits the chain.
+    /// </summary>
+    /// <param name="request">The request being handled.</param>
+    /// <param name="next">The continuation that invokes the next behavior or terminal handler.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <returns>A <see cref="Result{TResponse}"/> produced either by the chain or by this behavior directly.</returns>
+    Task<Result<TResponse>> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken);
+}

--- a/src/Memoria/Queries/QueryHandlerWrapper.cs
+++ b/src/Memoria/Queries/QueryHandlerWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Memoria.Results;
+using Memoria.Pipeline;
+using Memoria.Results;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Memoria.Queries;
@@ -14,7 +15,18 @@ internal class QueryHandlerWrapper<TQuery, TResult> : QueryHandlerWrapperBase<TR
             throw new InvalidOperationException($"Query handler for {typeof(IQuery<TResult>).Name} not found.");
         }
 
-        return await handler.Handle((TQuery)query, cancellationToken);
+        var typedQuery = (TQuery)query;
+        RequestHandlerDelegate<TResult> pipeline = () => handler.Handle(typedQuery, cancellationToken);
+
+        var behaviors = serviceProvider.GetServices<IPipelineBehavior<TQuery, TResult>>().Reverse().ToArray();
+        foreach (var behavior in behaviors)
+        {
+            var next = pipeline;
+            var current = behavior;
+            pipeline = () => current.Handle(typedQuery, next, cancellationToken);
+        }
+
+        return await pipeline();
     }
 }
 

--- a/tests/Memoria.Tests/Features/PipelineBehaviorTests.cs
+++ b/tests/Memoria.Tests/Features/PipelineBehaviorTests.cs
@@ -1,0 +1,314 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Memoria.Commands;
+using Memoria.Messaging;
+using Memoria.Notifications;
+using Memoria.Pipeline;
+using Memoria.Results;
+using Memoria.Queries;
+using Memoria.Caching;
+using Memoria.Tests.Models.Commands;
+using Memoria.Tests.Models.Commands.Handlers;
+using Memoria.Tests.Models.Pipeline;
+using Memoria.Tests.Models.Queries;
+using Memoria.Tests.Models.Queries.Handlers;
+using Memoria.Validation;
+using Memoria.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Memoria.Tests.Features;
+
+public class PipelineBehaviorTests
+{
+    private static CommandSender BuildSender(IServiceProvider serviceProvider) => new(
+        serviceProvider,
+        Substitute.For<IValidationService>(),
+        Substitute.For<INotificationPublisher>(),
+        Substitute.For<IMessagePublisher>());
+
+    [Fact]
+    public async Task PipelineBehavior_Should_Wrap_CommandHandler_With_Response()
+    {
+        var calls = new List<string>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>, CommandWithResultHandler>()
+            .AddSingleton<IPipelineBehavior<CommandWithResult, string>>(_ => new RecordingBehavior<CommandWithResult, string>("A", calls))
+            .BuildServiceProvider();
+
+        var result = await BuildSender(serviceProvider).Send(new CommandWithResult("test"));
+
+        using (new AssertionScope())
+        {
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be("test");
+            calls.Should().ContainInOrder("A:enter", "A:exit");
+        }
+    }
+
+    [Fact]
+    public async Task PipelineBehaviors_Should_Execute_In_Registration_Order_With_First_As_Outermost()
+    {
+        var calls = new List<string>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>, CommandWithResultHandler>()
+            .AddSingleton<IPipelineBehavior<CommandWithResult, string>>(_ => new RecordingBehavior<CommandWithResult, string>("A", calls))
+            .AddSingleton<IPipelineBehavior<CommandWithResult, string>>(_ => new RecordingBehavior<CommandWithResult, string>("B", calls))
+            .BuildServiceProvider();
+
+        await BuildSender(serviceProvider).Send(new CommandWithResult("test"));
+
+        calls.Should().Equal("A:enter", "B:enter", "B:exit", "A:exit");
+    }
+
+    [Fact]
+    public async Task PipelineBehavior_Can_ShortCircuit_By_Returning_Failure_Without_Calling_Next()
+    {
+        var handlerCalls = new List<string>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>>(_ => new RecordingHandler(handlerCalls))
+            .AddSingleton<IPipelineBehavior<CommandWithResult, string>>(_ => new ShortCircuitBehavior("denied"))
+            .BuildServiceProvider();
+
+        var result = await BuildSender(serviceProvider).Send(new CommandWithResult("test"));
+
+        using (new AssertionScope())
+        {
+            result.IsFailure.Should().BeTrue();
+            result.Failure!.Title.Should().Be("denied");
+            handlerCalls.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task PipelineBehavior_Can_Transform_The_Response_After_Calling_Next()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>, CommandWithResultHandler>()
+            .AddSingleton<IPipelineBehavior<CommandWithResult, string>>(_ => new TransformBehavior(v => v.ToUpperInvariant()))
+            .BuildServiceProvider();
+
+        var result = await BuildSender(serviceProvider).Send(new CommandWithResult("hello"));
+
+        using (new AssertionScope())
+        {
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be("HELLO");
+        }
+    }
+
+    [Fact]
+    public async Task PipelineBehavior_Should_Wrap_CommandHandler_Without_Response()
+    {
+        var calls = new List<string>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<SimpleCommand>, SimpleCommandHandler>()
+            .AddSingleton<IPipelineBehavior<SimpleCommand>>(_ => new RecordingBehavior<SimpleCommand>("A", calls))
+            .BuildServiceProvider();
+
+        var result = await BuildSender(serviceProvider).Send(new SimpleCommand("test"));
+
+        using (new AssertionScope())
+        {
+            result.IsSuccess.Should().BeTrue();
+            calls.Should().ContainInOrder("A:enter", "A:exit");
+        }
+    }
+
+    [Fact]
+    public async Task PipelineBehaviors_Should_Wrap_The_Custom_Func_CommandHandler_Overload()
+    {
+        var calls = new List<string>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IPipelineBehavior<SimpleCommand>>(_ => new RecordingBehavior<SimpleCommand>("A", calls))
+            .BuildServiceProvider();
+
+        var result = await BuildSender(serviceProvider).Send(new SimpleCommand("test"), () =>
+        {
+            calls.Add("custom-handler");
+            return Task.FromResult(Result.Ok());
+        });
+
+        using (new AssertionScope())
+        {
+            result.IsSuccess.Should().BeTrue();
+            calls.Should().Equal("A:enter", "custom-handler", "A:exit");
+        }
+    }
+
+    [Fact]
+    public async Task PipelineBehavior_Should_Wrap_QueryHandler()
+    {
+        var calls = new List<string>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IQueryHandler<GetGreeting, string>, GetGreetingHandler>()
+            .AddSingleton<IPipelineBehavior<GetGreeting, string>>(_ => new RecordingBehavior<GetGreeting, string>("A", calls))
+            .BuildServiceProvider();
+
+        var processor = new QueryProcessor(serviceProvider, Substitute.For<ICachingService>());
+
+        var result = await processor.Get(new GetGreeting("World"));
+
+        using (new AssertionScope())
+        {
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be("Hello, World");
+            calls.Should().ContainInOrder("A:enter", "A:exit");
+        }
+    }
+
+    [Fact]
+    public void AddMemoriaBehavior_Should_Throw_When_Type_Does_Not_Implement_IPipelineBehavior()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddMemoriaBehavior(typeof(string));
+
+        act.Should().Throw<ArgumentException>().WithMessage("*IPipelineBehavior*");
+    }
+
+    [Fact]
+    public void AddMemoriaBehavior_Should_Throw_When_Services_Is_Null()
+    {
+        IServiceCollection? services = null;
+
+        Action act = () => services!.AddMemoriaBehavior(typeof(RecordingBehavior<CommandWithResult, string>));
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddMemoriaBehavior_Should_Throw_When_BehaviorType_Is_Null()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddMemoriaBehavior((Type)null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task AddMemoriaBehavior_Typed_Overload_Should_Register_Closed_Behavior()
+    {
+        var calls = new List<string>();
+        var services = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>, CommandWithResultHandler>()
+            .AddSingleton(calls);
+        services.AddMemoriaBehavior<ClosedRecordingBehavior>();
+
+        var result = await BuildSender(services.BuildServiceProvider()).Send(new CommandWithResult("test"));
+
+        using (new AssertionScope())
+        {
+            result.IsSuccess.Should().BeTrue();
+            calls.Should().ContainInOrder("closed:enter", "closed:exit");
+        }
+    }
+
+    [Fact]
+    public async Task AddMemoriaBehavior_Should_Register_Open_Generic_Behavior()
+    {
+        var calls = new List<string>();
+        var services = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>, CommandWithResultHandler>()
+            .AddSingleton<ICommandHandler<SimpleCommand>, SimpleCommandHandler>()
+            .AddSingleton(calls);
+        services.AddMemoriaBehavior(typeof(OpenGenericRecordingBehavior<,>));
+
+        var sender = BuildSender(services.BuildServiceProvider());
+        await sender.Send(new CommandWithResult("test"));
+
+        calls.Should().Contain("open:enter").And.Contain("open:exit");
+    }
+
+    private sealed class ClosedRecordingBehavior(List<string> calls) : IPipelineBehavior<CommandWithResult, string>
+    {
+        public async Task<Result<string>> Handle(CommandWithResult request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+        {
+            calls.Add("closed:enter");
+            var result = await next();
+            calls.Add("closed:exit");
+            return result;
+        }
+    }
+
+    private sealed class OpenGenericRecordingBehavior<TRequest, TResponse>(List<string> calls) : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : notnull
+    {
+        public async Task<Result<TResponse>> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            calls.Add("open:enter");
+            var result = await next();
+            calls.Add("open:exit");
+            return result;
+        }
+    }
+
+    [Fact]
+    public async Task PipelineBehavior_With_No_Behaviors_Registered_Should_Invoke_Handler_Exactly_Once()
+    {
+        var handlerCalls = new List<string>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>>(_ => new RecordingHandler(handlerCalls))
+            .BuildServiceProvider();
+
+        var result = await BuildSender(serviceProvider).Send(new CommandWithResult("test"));
+
+        using (new AssertionScope())
+        {
+            result.IsSuccess.Should().BeTrue();
+            handlerCalls.Should().Equal("handler");
+        }
+    }
+
+    [Fact]
+    public async Task PipelineBehavior_Should_Receive_The_Same_CancellationToken_The_Dispatcher_Was_Called_With()
+    {
+        using var cts = new CancellationTokenSource();
+        var observed = new List<CancellationToken>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<ICommandHandler<CommandWithResult, string>, CommandWithResultHandler>()
+            .AddSingleton<IPipelineBehavior<CommandWithResult, string>>(_ => new CancellationCapturingBehavior(observed))
+            .BuildServiceProvider();
+
+        await BuildSender(serviceProvider).Send(new CommandWithResult("test"), cancellationToken: cts.Token);
+
+        observed.Should().Equal(cts.Token);
+    }
+
+    private sealed class CancellationCapturingBehavior(List<CancellationToken> observed) : IPipelineBehavior<CommandWithResult, string>
+    {
+        public Task<Result<string>> Handle(CommandWithResult request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+        {
+            observed.Add(cancellationToken);
+            return next();
+        }
+    }
+
+    private sealed class RecordingHandler(List<string> calls) : ICommandHandler<CommandWithResult, string>
+    {
+        public Task<Result<string>> Handle(CommandWithResult command, CancellationToken cancellationToken = default)
+        {
+            calls.Add("handler");
+            return Task.FromResult<Result<string>>(command.Name);
+        }
+    }
+
+    private sealed class ShortCircuitBehavior(string failureTitle) : IPipelineBehavior<CommandWithResult, string>
+    {
+        public Task<Result<string>> Handle(CommandWithResult request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Result<string>.Fail(title: failureTitle));
+        }
+    }
+
+    private sealed class TransformBehavior(Func<string, string> transform) : IPipelineBehavior<CommandWithResult, string>
+    {
+        public async Task<Result<string>> Handle(CommandWithResult request, RequestHandlerDelegate<string> next, CancellationToken cancellationToken)
+        {
+            var inner = await next();
+            return inner.IsSuccess ? transform(inner.Value!) : inner;
+        }
+    }
+}

--- a/tests/Memoria.Tests/Models/Commands/Handlers/CommandWithResultHandler.cs
+++ b/tests/Memoria.Tests/Models/Commands/Handlers/CommandWithResultHandler.cs
@@ -1,0 +1,12 @@
+using Memoria.Commands;
+using Memoria.Results;
+
+namespace Memoria.Tests.Models.Commands.Handlers;
+
+public class CommandWithResultHandler : ICommandHandler<CommandWithResult, string>
+{
+    public Task<Result<string>> Handle(CommandWithResult command, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<Result<string>>(command.Name);
+    }
+}

--- a/tests/Memoria.Tests/Models/Pipeline/RecordingBehavior.cs
+++ b/tests/Memoria.Tests/Models/Pipeline/RecordingBehavior.cs
@@ -1,0 +1,20 @@
+using Memoria.Pipeline;
+using Memoria.Results;
+
+namespace Memoria.Tests.Models.Pipeline;
+
+public class RecordingBehavior<TRequest, TResponse>(string name, List<string> calls)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public async Task<Result<TResponse>> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        calls.Add($"{name}:enter");
+        var result = await next();
+        calls.Add($"{name}:exit");
+        return result;
+    }
+}

--- a/tests/Memoria.Tests/Models/Pipeline/RecordingBehaviorNoResponse.cs
+++ b/tests/Memoria.Tests/Models/Pipeline/RecordingBehaviorNoResponse.cs
@@ -1,0 +1,21 @@
+using Memoria.Commands;
+using Memoria.Pipeline;
+using Memoria.Results;
+
+namespace Memoria.Tests.Models.Pipeline;
+
+public class RecordingBehavior<TRequest>(string name, List<string> calls)
+    : IPipelineBehavior<TRequest>
+    where TRequest : ICommand
+{
+    public async Task<Result> Handle(
+        TRequest request,
+        RequestHandlerDelegate next,
+        CancellationToken cancellationToken)
+    {
+        calls.Add($"{name}:enter");
+        var result = await next();
+        calls.Add($"{name}:exit");
+        return result;
+    }
+}


### PR DESCRIPTION
Introduce IPipelineBehavior<TRequest> and IPipelineBehavior<TRequest, TResponse> for cross-cutting concerns around command and query handling. Behaviors short-circuit by returning a Failure rather than throwing, matching Memoria's Result-based contract.

- Wired into CommandHandlerWrapper, QueryHandlerWrapper, and both CommandSender ICommand paths (DI-resolved and custom Func overload).
- Notifications and command sequences are intentionally not wrapped in v1.
- Validation and CacheableQuery remain on their existing dedicated paths.
- Opt-in registration via AddMemoriaBehavior<T>() / AddMemoriaBehavior(Type), supporting both closed and open generic behavior types.
- Ordering is registration order: first registered wraps outermost.
- New guide at docs/guides/pipeline-behaviors.md with logging, timing, and unit-of-work samples.